### PR TITLE
bump resolver version to 13.23

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-10.7
+resolver: lts-13.23
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Uses a newer ghc that parses MacOS gcc version correctly, since ghc
8.2.2 barfs if Cuda is installed. For more details, see the below
references:
https://github.com/commercialhaskell/stack/issues/3741
https://gitlab.haskell.org/ghc/ghc/issues/14724