### PR TITLE
Also read usage files from /usr/share/compleat.d

### DIFF
--- a/compleat_setup
+++ b/compleat_setup
@@ -4,10 +4,11 @@ _run_compleat() {
     compleat $@
 }
 
+[ -n "$COMPLEAT_VENDOR_DIR" ] || COMPLEAT_SYSTEM_DIR=/usr/share/compleat.d
 [ -n "$COMPLEAT_SYSTEM_DIR" ] || COMPLEAT_SYSTEM_DIR=/etc/compleat.d
 [ -n "$COMPLEAT_USER_DIR"   ] || COMPLEAT_USER_DIR=$HOME/.compleat
 
-for DIR in $COMPLEAT_SYSTEM_DIR $COMPLEAT_USER_DIR; do
+for DIR in $COMPLEAT_VENDOR_DIR $COMPLEAT_SYSTEM_DIR $COMPLEAT_USER_DIR; do
     if [ -d $DIR -a -r $DIR -a -x $DIR ]; then
         for FILE in $DIR/*.usage; do
             for COMMAND in `compleat $FILE`; do

--- a/compleat_setup.fish
+++ b/compleat_setup.fish
@@ -5,10 +5,11 @@ function _run_compleat
     compleat $argv
 end
 
+[ -n "$COMPLEAT_VENDOR_DIR" ]; or set COMPLEAT_SYSTEM_DIR /usr/share/compleat.d
 [ -n "$COMPLEAT_SYSTEM_DIR" ]; or set COMPLEAT_SYSTEM_DIR /etc/compleat.d
 [ -n "$COMPLEAT_USER_DIR"   ]; or set COMPLEAT_USER_DIR $HOME/.compleat
 
-for DIR in $COMPLEAT_SYSTEM_DIR $COMPLEAT_USER_DIR
+for DIR in $COMPLEAT_VENDOR_DIR $COMPLEAT_SYSTEM_DIR $COMPLEAT_USER_DIR
     if [ -d $DIR -a -r $DIR -a -x $DIR ]
         for FILE in $DIR/*.usage
             for COMMAND in (compleat $FILE)


### PR DESCRIPTION
I am creating a package for openSUSE and I want to include the example/*.usage files but /etc should only contain files marked as %config. Other completions (like for bash and fish) are also installed to folders in /usr/share.