### PR TITLE
Respect $BASH_COMPLETION_USER_DIR when installing completion file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
+XDG_DATA_HOME            ?= $(HOME)/.local/share
+BASH_COMPLETION_USER_DIR ?= $(XDG_DATA_HOME)/bash-completion/completions
+
 build:
 	stack build
 .PHONY: build
 
 install: build
 	stack install
-	install -d ~/.bash_completion.d
-	install -m 0644 compleat_setup ~/.bash_completion.d
+	install -d $(BASH_COMPLETION_USER_DIR)
+	install -m 0644 compleat_setup $(BASH_COMPLETION_USER_DIR)
 .PHONY: install
 
 install-fish: build

--- a/README.markdown
+++ b/README.markdown
@@ -22,14 +22,16 @@ To install Compleat in your system, run:
     make install
 
 This will install the `compleat` binary into `~/.local/bin` and the
-`compleat_setup` script into `~/.bash_completion.d`.
+`compleat_setup` script into `$BASH_COMPLETION_USER_DIR` (defaults to
+`$XDG_DATA_HOME/bash-completion/completions` or
+`~/.local/share/bash-completion/completions`):
 
 ### bash
 
 To enable compleat in bash, add the following line to your `.bashrc`.
 (Adjust the path if you configured with a custom prefix.)
 
-    source ~/.bash_completion.d/compleat_setup
+    source ${BASH_COMPLETION_USER_DIR}/compleat_setup
 
 and install your .usage files in a directory named `/etc/compleat.d` or
 `~/.compleat`:


### PR DESCRIPTION
There is not really a standard place for user completion files for bash. According to [this Stack Exchange answer](https://serverfault.com/a/1013395/23484), the bash-completion package respects an environment variable called `$BASH_COMPLETION_USER_DIR`, using defaults as follows:

1. `$BASH_COMPLETION_USER_DIR`, if it exists
2. `$XDG_DATA_HOME/bash-completion/completions`, if `$XDG_DATA_HOME` exists
3. `~/.local/share/bash-completion/completions` if neither `$BASH_COMPLETION_USER_DIR` nor `$XDG_DATA_HOME` is set

Since that is as close to a standard as we can get in bash, we should replicate that standard when installing our own bash completion script.